### PR TITLE
Add Dockerfile for API server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+__pycache__
+tests
+benchmarks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN pip install --no-cache-dir pip && \
+    pip install --no-cache-dir fastapi==0.115.4 uvicorn==0.32.0 python-multipart==0.0.16 && \
+    pip install --no-cache-dir .
+
+EXPOSE 8000
+CMD ["uvicorn", "marker.scripts.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -415,6 +415,19 @@ pip install -U uvicorn fastapi python-multipart
 marker_server --port 8001
 ```
 
+### Docker
+
+You can also run the server in a container. Build the image from the provided
+`Dockerfile` and expose the default FastAPI port:
+
+```bash
+docker build -t marker-api .
+docker run -p 8001:8000 marker-api
+```
+
+The server uses the most common conversion settings – converting the entire
+document to Markdown without forcing OCR or pagination.
+
 This will start a fastapi server that you can access at `localhost:8001`.  You can go to `localhost:8001/docs` to see the endpoint options.
 
 You can send requests like this:


### PR DESCRIPTION
## Summary
- provide a Dockerfile to run the FastAPI server
- ignore unnecessary files when building the image
- document how to run the server in Docker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686d2b84455c832f9dfcad31342529c7